### PR TITLE
Use os.(*File).ReadDir to improve performance

### DIFF
--- a/file.go
+++ b/file.go
@@ -9,14 +9,16 @@ package gocodewalker
 import (
 	"bytes"
 	"errors"
-	"github.com/boyter/gocodewalker/go-gitignore"
-	"golang.org/x/sync/errgroup"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/boyter/gocodewalker/go-gitignore"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -239,7 +241,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 	}
 	defer d.Close()
 
-	foundFiles, err := d.Readdir(-1)
+	foundFiles, err := d.ReadDir(-1)
 	if err != nil {
 		// nothing we can do with this so return nil and process as best we can
 		if f.errorsHandler(err) {
@@ -248,8 +250,8 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 		return err
 	}
 
-	files := []os.FileInfo{}
-	dirs := []os.FileInfo{}
+	files := []fs.DirEntry{}
+	dirs := []fs.DirEntry{}
 
 	// We want to break apart the files and directories from the
 	// return as we loop over them differently and this avoids some
@@ -409,7 +411,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 
 		// Ignore hidden files
 		if !f.IncludeHidden {
-			s, err := IsHidden(file, directory)
+			s, err := IsHiddenDirEntry(file, directory)
 			if err != nil {
 				if !f.errorsHandler(err) {
 					return err
@@ -555,7 +557,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 
 		// Ignore hidden directories
 		if !f.IncludeHidden {
-			s, err := IsHidden(dir, directory)
+			s, err := IsHiddenDirEntry(dir, directory)
 			if err != nil {
 				if !f.errorsHandler(err) {
 					return err

--- a/hidden.go
+++ b/hidden.go
@@ -5,10 +5,16 @@
 package gocodewalker
 
 import (
+	"io/fs"
 	"os"
 )
 
 // IsHidden Returns true if file is hidden
 func IsHidden(file os.FileInfo, directory string) (bool, error) {
+	return IsHiddenDirEntry(fs.FileInfoToDirEntry(file), directory)
+}
+
+// IsHiddenDirEntry is similar to [IsHidden], excepts it accepts [fs.DirEntry] as its argument
+func IsHiddenDirEntry(file fs.DirEntry, directory string) (bool, error) {
 	return file.Name()[0:1] == ".", nil
 }

--- a/hidden_windows.go
+++ b/hidden_windows.go
@@ -5,6 +5,7 @@
 package gocodewalker
 
 import (
+	"io/fs"
 	"os"
 	"path"
 	"syscall"
@@ -12,6 +13,11 @@ import (
 
 // IsHidden Returns true if file is hidden
 func IsHidden(file os.FileInfo, directory string) (bool, error) {
+	return IsHiddenDirEntry(fs.FileInfoToDirEntry(file), directory)
+}
+
+// IsHiddenDirEntry is similar to [IsHidden], excepts it accepts [fs.DirEntry] as its argument
+func IsHiddenDirEntry(file fs.DirEntry, directory string) (bool, error) {
 	fullpath := path.Join(directory, file.Name())
 	pointer, err := syscall.UTF16PtrFromString(fullpath)
 	if err != nil {


### PR DESCRIPTION
os.(*File).ReadDir is usually 1~2x faster than os.(*File).Readdir if we only use dir-entry's `Name()`, `Type()` and `IsDir()` methods.

I tested with "cmd/gocodewalkerperformance", and it shows an overall 15% improvement in performance:

(proj/go is the golang/go repo, it includes 12k+ files.)

![benchmark](https://github.com/user-attachments/assets/1dc0f3a4-ed5e-4d6f-92b1-3508f00d5596)

