### PR TITLE
ci: fix warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,14 +11,14 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.19', '1.20']
+        go: ['1.20', '1.21', '1.22']
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
       id: go


### PR DESCRIPTION
Fix warnings and add Go1.22, Go1.21 tests.

Warnings like these:
![image](https://github.com/user-attachments/assets/c028bed9-2a18-457a-b734-9f360619154c)
