### PR TITLE
feat: let ExcludeDirectory support multi-level dirs

### DIFF
--- a/dir_suffix.go
+++ b/dir_suffix.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+package gocodewalker
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// isSuffixDir returns true if base ends with suffix. Suffix "/" will be trimmed.
+// suffix must be a valid sub dir of base.
+// For examples:
+//   - isSuffixDir("a", "a") returns true
+//   - isSuffixDir("a/b/c", "c") returns true
+//   - isSuffixDir("a/b/c", "b/c") returns true
+//   - isSuffixDir("a/b/c", "b") returns false
+//   - isSuffixDir("a/b/c", "a/b") returns false, "a/b" is a valid sub dir but not at the end of "a/b/c"
+//   - isSuffixDir("a/bb/c", "b/c") returns false
+func isSuffixDir(base string, suffix string) bool {
+	if base == "" || suffix == "" {
+		return false
+	}
+	base = strings.TrimSuffix(filepath.ToSlash(base), "/")
+	suffix = strings.TrimSuffix(filepath.ToSlash(suffix), "/")
+	newBase := strings.TrimSuffix(base, suffix)
+	if newBase == base {
+		return false
+	}
+	return strings.HasSuffix(newBase, "/") || newBase == ""
+}

--- a/dir_suffix_test.go
+++ b/dir_suffix_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+
+package gocodewalker
+
+import "testing"
+
+func TestIsSuffixDir(t *testing.T) {
+	testCases := []struct {
+		base   string
+		suffix string
+		expect bool
+	}{
+		{
+			base:   "",
+			suffix: "",
+			expect: false,
+		},
+		{
+			base:   "a",
+			suffix: "",
+			expect: false,
+		},
+		{
+			base:   "",
+			suffix: "a",
+			expect: false,
+		},
+		{
+			base:   "a",
+			suffix: "a",
+			expect: true,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "a/b/c",
+			expect: true,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "c",
+			expect: true,
+		},
+		{
+			base:   "c",
+			suffix: "a/b/c",
+			expect: false,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "b/c",
+			expect: true,
+		},
+		{
+			base:   "/a/b/c",
+			suffix: "b/c",
+			expect: true,
+		},
+		{
+			base:   "/a/b/c",
+			suffix: "/b/c",
+			expect: false,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "/b/c",
+			expect: false,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "b",
+			expect: false,
+		},
+		{
+			base:   "a/b/c",
+			suffix: "a/b",
+			expect: false,
+		},
+		{
+			base:   "a/b/c/d",
+			suffix: "b/c",
+			expect: false,
+		},
+		{
+			base:   "a/bb/c",
+			suffix: "b/c",
+			expect: false,
+		},
+		{
+			base:   "C:/a/b",
+			suffix: "a/b",
+			expect: true,
+		},
+		{
+			base:   "C:/a/b",
+			suffix: "/a/b",
+			expect: false,
+		},
+		{
+			base:   "C:/a/b",
+			suffix: "D:/a/b",
+			expect: false,
+		},
+		{
+			base:   "b/b/c",
+			suffix: "b/b/c/",
+			expect: true,
+		},
+	}
+	for _, tc := range testCases {
+		res := isSuffixDir(tc.base, tc.suffix)
+		if res != tc.expect {
+			t.Errorf("base: %s, suffix: %s, got: %v, want: %v", tc.base, tc.suffix, res, tc.expect)
+		}
+	}
+}

--- a/file.go
+++ b/file.go
@@ -581,7 +581,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 		// things like .git .hg and .svn
 		// Comes after include as it takes precedence
 		for _, deny := range f.ExcludeDirectory {
-			if dir.Name() == deny {
+			if isSuffixDir(joined, deny) {
 				shouldIgnore = true
 			}
 		}

--- a/file_test.go
+++ b/file_test.go
@@ -510,6 +510,52 @@ func TestNewFileWalkerDirectoryCases(t *testing.T) {
 			Expected: 1,
 		},
 		{
+			Name: "ExcludeDirectory multi-level 1",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				d2 := filepath.Join(d, "stuff")
+				_ = os.Mkdir(d2, 0777)
+				_, _ = os.Create(filepath.Join(d2, "/test.md"))
+				d3 := filepath.Join(d2, "multi")
+				_ = os.Mkdir(d3, 0777)
+				_, _ = os.Create(filepath.Join(d3, "/test.md"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.ExcludeDirectory = []string{"stuff/multi"}
+				return walker, fileListQueue
+			},
+			Expected: 1,
+		},
+		{
+			Name: "ExcludeDirectory multi-level 2",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				d2 := filepath.Join(d, "stuff")
+				_ = os.Mkdir(d2, 0777)
+				_, _ = os.Create(filepath.Join(d2, "/test.md"))
+				d3 := filepath.Join(d2, "multi")
+				_ = os.Mkdir(d3, 0777)
+				_, _ = os.Create(filepath.Join(d3, "/test.md"))
+
+				d4 := filepath.Join(d2, "another/stuff/multi")
+				_ = os.MkdirAll(d4, 0777)
+				_, _ = os.Create(filepath.Join(d4, "/test.md"))
+
+				d5 := filepath.Join(d2, "another/sstuff/multi")
+				_ = os.MkdirAll(d5, 0777)
+				_, _ = os.Create(filepath.Join(d5, "/test.md"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.ExcludeDirectory = []string{"stuff/multi"}
+				return walker, fileListQueue
+			},
+			Expected: 2,
+		},
+		{
 			Name: "IncludeDirectory 1",
 			Case: func() (*FileWalker, chan *File) {
 				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))


### PR DESCRIPTION
Support multi-level exclude dir that I described in scc#564. More examples can be found in the tests.

`isSuffixDir` will cause a slight performance degradation. We can not just use `strings.HasSuffix` to check it ("a/bb/c" does not end with "b/c"), so the performance cost is necessary.