### PR TITLE
Ignore patterns from code and more sensible channel requirements

### DIFF
--- a/file.go
+++ b/file.go
@@ -388,6 +388,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 		}
 	}
 
+	// If we have custom ignore patterns defined we should concatenate them and treat them as a single gitignore file
 	if len(f.CustomIgnorePatterns) > 0 {
 		customIgnorePatternsCombined := strings.Join(f.CustomIgnorePatterns, "\n")
 		gitIgnore := gitignore.New(bytes.NewReader([]byte(customIgnorePatternsCombined)), directory, nil)

--- a/file.go
+++ b/file.go
@@ -40,7 +40,7 @@ type File struct {
 var semaphoreCount = 8
 
 type FileWalker struct {
-	fileListQueue          chan *File
+	fileListQueue          chan<- *File
 	errorsHandler          func(error) bool // If returns true will continue to process where possible, otherwise returns if possible
 	directory              string
 	directories            []string
@@ -61,7 +61,8 @@ type FileWalker struct {
 	IgnoreIgnoreFile       bool     // Should .ignore files be respected?
 	IgnoreGitIgnore        bool     // Should .gitignore files be respected?
 	IgnoreGitModules       bool     // Should .gitmodules files be respected?
-	CustomIgnore           []string // Custom ignore files
+	CustomIgnoreFiles      []string // Custom ignore files
+	CustomIgnorePatterns   []string //Custom ignore patterns
 	IncludeHidden          bool     // Should hidden files and directories be included/walked
 	osOpen                 func(name string) (*os.File, error)
 	osReadFile             func(name string) ([]byte, error)
@@ -72,7 +73,7 @@ type FileWalker struct {
 
 // NewFileWalker constructs a filewalker, which will walk the supplied directory
 // and output File results to the supplied queue as it finds them
-func NewFileWalker(directory string, fileListQueue chan *File) *FileWalker {
+func NewFileWalker(directory string, fileListQueue chan<- *File) *FileWalker {
 	return &FileWalker{
 		fileListQueue:          fileListQueue,
 		errorsHandler:          func(e error) bool { return true }, // a generic one that just swallows everything
@@ -93,7 +94,8 @@ func NewFileWalker(directory string, fileListQueue chan *File) *FileWalker {
 		isWalking:              false,
 		IgnoreIgnoreFile:       false,
 		IgnoreGitIgnore:        false,
-		CustomIgnore:           []string{},
+		CustomIgnoreFiles:      []string{},
+		CustomIgnorePatterns:   []string{},
 		IgnoreGitModules:       false,
 		IncludeHidden:          false,
 		osOpen:                 os.Open,
@@ -106,7 +108,7 @@ func NewFileWalker(directory string, fileListQueue chan *File) *FileWalker {
 
 // NewParallelFileWalker constructs a filewalker, which will walk the supplied directories in parallel
 // and output File results to the supplied queue as it finds them
-func NewParallelFileWalker(directories []string, fileListQueue chan *File) *FileWalker {
+func NewParallelFileWalker(directories []string, fileListQueue chan<- *File) *FileWalker {
 	return &FileWalker{
 		fileListQueue:          fileListQueue,
 		errorsHandler:          func(e error) bool { return true }, // a generic one that just swallows everything
@@ -127,7 +129,8 @@ func NewParallelFileWalker(directories []string, fileListQueue chan *File) *File
 		isWalking:              false,
 		IgnoreIgnoreFile:       false,
 		IgnoreGitIgnore:        false,
-		CustomIgnore:           []string{},
+		CustomIgnoreFiles:      []string{},
+		CustomIgnorePatterns:   []string{},
 		IgnoreGitModules:       false,
 		IncludeHidden:          false,
 		osOpen:                 os.Open,
@@ -361,7 +364,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 			}
 		}
 
-		for _, ci := range f.CustomIgnore {
+		for _, ci := range f.CustomIgnoreFiles {
 			if file.Name() == ci {
 				c, err := f.osReadFile(filepath.Join(directory, file.Name()))
 				if err != nil {
@@ -383,6 +386,12 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 				customIgnores = append(customIgnores, gitIgnore)
 			}
 		}
+	}
+
+	if len(f.CustomIgnorePatterns) > 0 {
+		customIgnorePatternsCombined := strings.Join(f.CustomIgnorePatterns, "\n")
+		gitIgnore := gitignore.New(bytes.NewReader([]byte(customIgnorePatternsCombined)), directory, nil)
+		customIgnores = append(customIgnores, gitIgnore)
 	}
 
 	// Process files first to start feeding whatever process is consuming

--- a/file.go
+++ b/file.go
@@ -61,7 +61,7 @@ type FileWalker struct {
 	IgnoreIgnoreFile       bool     // Should .ignore files be respected?
 	IgnoreGitIgnore        bool     // Should .gitignore files be respected?
 	IgnoreGitModules       bool     // Should .gitmodules files be respected?
-	CustomIgnoreFiles      []string // Custom ignore files
+	CustomIgnore           []string // Custom ignore files
 	CustomIgnorePatterns   []string //Custom ignore patterns
 	IncludeHidden          bool     // Should hidden files and directories be included/walked
 	osOpen                 func(name string) (*os.File, error)
@@ -94,7 +94,7 @@ func NewFileWalker(directory string, fileListQueue chan<- *File) *FileWalker {
 		isWalking:              false,
 		IgnoreIgnoreFile:       false,
 		IgnoreGitIgnore:        false,
-		CustomIgnoreFiles:      []string{},
+		CustomIgnore:           []string{},
 		CustomIgnorePatterns:   []string{},
 		IgnoreGitModules:       false,
 		IncludeHidden:          false,
@@ -129,7 +129,7 @@ func NewParallelFileWalker(directories []string, fileListQueue chan<- *File) *Fi
 		isWalking:              false,
 		IgnoreIgnoreFile:       false,
 		IgnoreGitIgnore:        false,
-		CustomIgnoreFiles:      []string{},
+		CustomIgnore:           []string{},
 		CustomIgnorePatterns:   []string{},
 		IgnoreGitModules:       false,
 		IncludeHidden:          false,
@@ -364,7 +364,7 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 			}
 		}
 
-		for _, ci := range f.CustomIgnoreFiles {
+		for _, ci := range f.CustomIgnore {
 			if file.Name() == ci {
 				c, err := f.osReadFile(filepath.Join(directory, file.Name()))
 				if err != nil {


### PR DESCRIPTION
I have added the ability to set a custom list of strings which are combined into a single custom gitignore file without creating a file on disk. Useful for adding extra patterns at runtime that follow the gitignore pattern matching.

I also removed the requirement to give a full channel to the FileWalker. You now only need to give it the send side