### PR TITLE
Fix CustomIgnorePatterns not working for relative directories

### DIFF
--- a/file.go
+++ b/file.go
@@ -404,7 +404,15 @@ func (f *FileWalker) walkDirectoryRecursive(iteration int,
 	// If we have custom ignore patterns defined we should concatenate them and treat them as a single gitignore file
 	if len(f.CustomIgnorePatterns) > 0 {
 		customIgnorePatternsCombined := strings.Join(f.CustomIgnorePatterns, "\n")
-		gitIgnore := gitignore.New(bytes.NewReader([]byte(customIgnorePatternsCombined)), directory, nil)
+
+		abs, err := filepath.Abs(directory)
+		if err != nil {
+			if !f.errorsHandler(err) {
+				return err
+			}
+		}
+
+		gitIgnore := gitignore.New(bytes.NewReader([]byte(customIgnorePatternsCombined)), abs, nil)
 		customIgnores = append(customIgnores, gitIgnore)
 	}
 

--- a/file_test.go
+++ b/file_test.go
@@ -473,6 +473,64 @@ func TestNewFileWalkerFileCases(t *testing.T) {
 			},
 			Expected: 0,
 		},
+		{
+			Name: "CustomIgnorePatterns 0",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "test.md"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.CustomIgnorePatterns = []string{"*.md"}
+				return walker, fileListQueue
+			},
+			Expected: 0,
+		},
+		{
+			Name: "CustomIgnorePatterns 1",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "test.md"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.CustomIgnorePatterns = []string{"*.go"}
+				return walker, fileListQueue
+			},
+			Expected: 1,
+		},
+		{
+			Name: "CustomIgnorePatterns relative 0",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "test.md"))
+				_ = os.Chdir(d)
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(".", fileListQueue)
+
+				walker.CustomIgnorePatterns = []string{"*.md"}
+				return walker, fileListQueue
+			},
+			Expected: 0,
+		},
+		{
+			Name: "CustomIgnorePatterns relative 1",
+			Case: func() (*FileWalker, chan *File) {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "test.md"))
+				_ = os.Chdir(d)
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(".", fileListQueue)
+
+				walker.CustomIgnorePatterns = []string{"*.go"}
+				return walker, fileListQueue
+			},
+			Expected: 1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -738,7 +796,7 @@ func TestNewFileWalkerBinary(t *testing.T) {
 
 				d3 := filepath.Join(d2, "more_stuff")
 				_ = os.Mkdir(d3, 0777)
-				
+
 				nullByte := []byte{0}
 				_ = os.WriteFile(filepath.Join(d3, "null.txt"), nullByte, 0644)
 				_ = os.WriteFile(filepath.Join(d3, "null2.txt"), nullByte, 0644)

--- a/file_test.go
+++ b/file_test.go
@@ -242,6 +242,34 @@ func TestNewFileWalkerIgnoreFileCases(t *testing.T) {
 			},
 			ExpectCall: true,
 		},
+		{
+			Name: "custom ignore file ignore",
+			Case: func() *FileWalker {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "custom.ignore"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.CustomIgnore = []string{}
+				return walker
+			},
+			ExpectCall: false,
+		},
+		{
+			Name: "custom ignore file include",
+			Case: func() *FileWalker {
+				d, _ := os.MkdirTemp(os.TempDir(), randSeq(10))
+				_, _ = os.Create(filepath.Join(d, "custom.ignore"))
+
+				fileListQueue := make(chan *File, 10)
+				walker := NewFileWalker(d, fileListQueue)
+
+				walker.CustomIgnore = []string{"custom.ignore"}
+				return walker
+			},
+			ExpectCall: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When CustomIgnorePatterns is specified, it seems that files cannot be ignored as expected when executed with a relative path such as `NewFileWalker(".", fileListQueue)`.

Looking at the example code, specifying a directory like this seems valid, so I would like it to work in this case too.