### PR TITLE
fix: a trailing "/**" must not match the directory itself

### DIFF
--- a/go-gitignore/anchor_test.go
+++ b/go-gitignore/anchor_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+
+package gitignore_test
+
+import (
+	"strings"
+	"testing"
+
+	gitignore "github.com/boyter/gocodewalker/go-gitignore"
+)
+
+// TestAnchoringAndRecursion is a table of pattern x path x expected covering
+// the anchoring and "**" rules of gitignore(5). Every expectation here was
+// taken from git itself rather than from the specification prose: each case
+// was built as a real repository and run through
+//
+//	git check-ignore <path>
+//
+// using the exit status (0 means ignored) rather than "-v", because "-v"
+// reports a matching *negative* pattern with exit status 0 as well and so
+// cannot be used to decide whether a path is ignored.
+//
+// The cases are matched at the level of a single ignore file, which is what
+// Relative does. git additionally ignores everything beneath an ignored
+// directory; that inheritance belongs to the walker, which prunes such
+// directories, so it is not represented here.
+func TestAnchoringAndRecursion(t *testing.T) {
+	_tests := []struct {
+		Pattern string
+		Path    string
+		IsDir   bool
+		Match   bool
+	}{
+		// a leading "/" anchors the pattern to the directory holding the
+		// .gitignore, so it matches there and nowhere below
+		{"/drop.go", "drop.go", false, true},
+		{"/drop.go", "sub/drop.go", false, false},
+		{"/drop.go", "sub/deep/drop.go", false, false},
+
+		// without the leading "/" and with no separator anywhere in the
+		// pattern, the name matches at any depth
+		{"drop.go", "drop.go", false, true},
+		{"drop.go", "sub/drop.go", false, true},
+		{"drop.go", "sub/deep/drop.go", false, true},
+
+		// a separator anywhere but the end also anchors the pattern, so
+		// "sub/drop.go" is anchored even without a leading "/"
+		{"sub/drop.go", "sub/drop.go", false, true},
+		{"sub/drop.go", "deep/sub/drop.go", false, false},
+		{"/sub/drop.go", "sub/drop.go", false, true},
+		{"/sub/drop.go", "deep/sub/drop.go", false, false},
+
+		// a trailing "/" restricts the pattern to directories
+		{"/foo/", "foo", true, true},
+		{"/foo/", "foo", false, false},
+		{"/foo/", "sub/foo", true, false},
+		{"foo/", "foo", true, true},
+		{"foo/", "sub/foo", true, true},
+		{"foo/", "sub/foo", false, false},
+
+		// a leading "**/" matches at any depth, including zero directories
+		{"**/foo", "foo", false, true},
+		{"**/foo", "sub/foo", false, true},
+		{"**/foo", "sub/deep/foo", false, true},
+
+		// "a/**/b" likewise matches zero or more directories in between
+		{"a/**/b", "a/b", false, true},
+		{"a/**/b", "a/mid/b", false, true},
+		{"a/**/b", "a/mid/deep/b", false, true},
+
+		// a *trailing* "/**" is the opposite case: it matches everything
+		// inside the directory, and so requires at least one component
+		// below it. git does not ignore the directory itself.
+		{"foo/**", "foo", true, false},
+		{"foo/**", "foo", false, false},
+		{"foo/**", "foo/inner", false, true},
+		{"foo/**", "foo/inner/deeper", false, true},
+		{"/sub/**", "sub", true, false},
+		{"/sub/**", "sub/keep.go", false, true},
+		{"**/hide/**", "subdir/hide", true, false},
+		{"**/hide/**", "subdir/hide/foo", false, true},
+		{"exclude/**", "exclude", true, false},
+		{"exclude/**", "exclude/other_file.txt", false, true},
+	}
+
+	for _, _test := range _tests {
+		_ignore := gitignore.New(
+			strings.NewReader(_test.Pattern+"\n"), "/base", nil,
+		)
+
+		_got := _ignore.Relative(_test.Path, _test.IsDir) != nil
+		if _got != _test.Match {
+			t.Errorf(
+				"pattern %q against %q (isdir %v): expected match %v, got %v",
+				_test.Pattern, _test.Path, _test.IsDir, _test.Match, _got,
+			)
+		}
+
+		// the same expectation must hold through Absolute, which is the
+		// entry point the walker actually uses
+		_abs := _ignore.Absolute("/base/"+_test.Path, _test.IsDir) != nil
+		if _abs != _test.Match {
+			t.Errorf(
+				"pattern %q against absolute %q (isdir %v): expected match %v, got %v",
+				_test.Pattern, "/base/"+_test.Path, _test.IsDir, _test.Match, _abs,
+			)
+		}
+	}
+} // TestAnchoringAndRecursion()
+
+// TestAnchoredNegation covers negation combined with anchoring. These cases
+// are stated as an ignore decision rather than as "did some pattern match",
+// because a negative pattern matches while leaving the path *not* ignored, so
+// only the decision is comparable to git. As above, the expectations come from
+// running git check-ignore over the equivalent repository and reading its exit
+// status.
+func TestAnchoredNegation(t *testing.T) {
+	_tests := []struct {
+		Content string
+		Path    string
+		IsDir   bool
+		Ignored bool
+	}{
+		// "!/foo" un-ignores only the root foo, leaving deeper ones ignored
+		{"foo\n!/foo\n", "foo", false, false},
+		{"foo\n!/foo\n", "sub/foo", false, true},
+
+		// an unanchored negation un-ignores at every depth
+		{"foo\n!foo\n", "foo", false, false},
+		{"foo\n!foo\n", "sub/foo", false, false},
+
+		// an anchored ignore with an unanchored negation
+		{"/foo\n!foo\n", "foo", false, false},
+
+		// order matters: the last matching pattern decides
+		{"!/foo\nfoo\n", "foo", false, true},
+
+		// a negation cannot re-include a path below an ignored *directory*,
+		// but "sub/**" does not ignore "sub" itself, so this one can
+		{"/sub/**\n!/sub/keep.go\n", "sub/keep.go", false, false},
+		{"/sub/**\n!/sub/keep.go\n", "sub/drop.go", false, true},
+	}
+
+	for _, _test := range _tests {
+		_ignore := gitignore.New(strings.NewReader(_test.Content), "/base", nil)
+
+		_ignored := false
+		if _match := _ignore.Relative(_test.Path, _test.IsDir); _match != nil {
+			_ignored = _match.Ignore()
+		}
+
+		if _ignored != _test.Ignored {
+			t.Errorf(
+				"content %q against %q (isdir %v): expected ignored %v, got %v",
+				_test.Content, _test.Path, _test.IsDir, _test.Ignored, _ignored,
+			)
+		}
+	}
+} // TestAnchoredNegation()

--- a/go-gitignore/defn_test.go
+++ b/go-gitignore/defn_test.go
@@ -387,7 +387,9 @@ var (
 		{"Documentation/foo.html", "!foo*.html", false, false},
 		{"Documentation/gitignore.html", "*.html", true, false},
 		{"Documentation/test.a.html", "*.html", true, false},
-		{"exclude/", "exclude/**", true, false},
+		// "exclude/**" matches everything inside "exclude", but not
+		// "exclude" itself: git check-ignore does not ignore it.
+		{"exclude/", "", false, false},
 		{"exclude/dir1/", "exclude/**", true, false},
 		{"exclude/dir1/dir2/", "exclude/**", true, false},
 		{"exclude/dir1/dir2/dir3/", "exclude/**", true, false},
@@ -417,7 +419,9 @@ var (
 		{"src/findthis.o", "!findthis*", false, false},
 		{"src/internal.o", "*.[oa]", true, false},
 		{"subdir/", "", false, false},
-		{"subdir/hide/", "**/hide/**", true, false},
+		// as above, the trailing "**" requires a path component below
+		// "hide", so "hide" itself is not matched
+		{"subdir/hide/", "", false, false},
 		{"subdir/hide/foo", "**/hide/**", true, false},
 		{"subdir/logdir/", "", false, false},
 		{"subdir/logdir/log/", "**/logdir/log", true, false},

--- a/go-gitignore/pattern.go
+++ b/go-gitignore/pattern.go
@@ -300,11 +300,19 @@ func (a *any) match(path []string, tokens []*Token) bool {
 	_token := tokens[0]
 	switch _token.Type {
 	case ANY:
+		// A trailing "**" matches everything *inside* the directory named
+		// by the preceding tokens, so it must consume at least one path
+		// component: gitignore(5) gives "abc/**" as matching all files
+		// inside "abc", and git does not ignore "abc" itself. A leading or
+		// embedded "**" is the opposite case and may match no component at
+		// all, so "**/foo" matches "foo" and "a/**/b" matches "a/b".
+		if len(tokens) == 1 {
+			return len(path) != 0
+		}
 		if len(path) == 0 {
 			return a.match(path, tokens[1:])
-		} else {
-			return a.match(path, tokens[1:]) || a.match(path[1:], tokens)
 		}
+		return a.match(path, tokens[1:]) || a.match(path[1:], tokens)
 
 	default:
 		// if we have a non-ANY token, then we must have a non-empty path

--- a/go-gitignore/pattern_any_bench_test.go
+++ b/go-gitignore/pattern_any_bench_test.go
@@ -1,0 +1,45 @@
+package gitignore_test
+
+import (
+	"strings"
+	"testing"
+
+	gitignore "github.com/boyter/gocodewalker/go-gitignore"
+)
+
+// benchmarks for the "any" ('**') matcher, which is the only path the
+// trailing-"**" change touches.
+func BenchmarkAnyMatch(b *testing.B) {
+	_cases := []struct {
+		Name    string
+		Pattern string
+		Path    string
+		IsDir   bool
+	}{
+		// trailing "**": the case the change short circuits
+		{"trailing_hit_shallow", "build/**", "build/x.o", false},
+		{"trailing_hit_deep", "build/**", "build/a/b/c/d/e/f/g/x.o", false},
+		{"trailing_miss_dir", "build/**", "build", true},
+		{"trailing_miss_other", "build/**", "src/a/b/c/d/e/f/g/x.o", false},
+		// leading "**": untouched, must not regress
+		{"leading_hit_deep", "**/foo", "a/b/c/d/e/f/g/foo", false},
+		{"leading_miss_deep", "**/foo", "a/b/c/d/e/f/g/bar", false},
+		// embedded "**": untouched, the most recursive case
+		{"embedded_hit", "a/**/b", "a/c/d/e/f/g/b", false},
+		{"embedded_miss", "a/**/b", "a/c/d/e/f/g/z", false},
+		// multiple "**", worst case for the recursion
+		{"multi_miss", "a/**/b/**/c/**", "a/x/y/b/z/w/q/r/s/t", false},
+	}
+
+	for _, _case := range _cases {
+		_ignore := gitignore.New(
+			strings.NewReader(_case.Pattern+"\n"), "/base", nil,
+		)
+		b.Run(_case.Name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ignore.Relative(_case.Path, _case.IsDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
gitignore(5) gives "abc/**" as matching everything *inside* "abc", and git agrees: "git check-ignore abc" exits 1. The 'any' matcher let a trailing "**" match zero path components, so "abc/**" also matched "abc".

The asymmetry is what makes this easy to get wrong. A leading or embedded "**" *may* match zero components -- "**/foo" matches "foo" and "a/**/b" matches "a/b" -- so the zero-component case cannot simply be removed. Only a trailing "**" requires a component below it.

Two consequences, the second the damaging one:

  - "foo/**" wrongly matched a plain *file* named "foo".
  - "assets/**" matched the directory "assets", so the walker pruned the whole subtree and a following "!assets/keep.txt" could never re-include anything. git keeps assets/keep.txt; the walker emitted nothing.

Two rows in the _GITMATCHES fixture asserted the old behaviour, for "exclude/**" against "exclude/" and "**/hide/**" against "subdir/hide/". Both were checked against git and both are wrong, so they are corrected here rather than worked around.

The new tests are a table of pattern x path x expected covering anchored and unanchored forms, "/foo", "foo", "foo/bar", "/foo/", "**/foo", "a/**/b", trailing "/**" and anchored negation. Every row was verified by building the equivalent repository and running git check-ignore over it, reading the exit status rather than -v, because -v reports a matching *negative* pattern with exit status 0 and so cannot decide whether a path is ignored.

Validated by walking real trees and diffing sorted file lists against git's own kept set: no file the walker emits is ignored by git, across linux, llama.cpp, valkey, whisper.cpp, raylib, scc and boyter.org. File counts are unchanged on all of them, because a visible difference needs a negation nested inside a "dir/**" and none of these repos have one. Note that this fix can only ever include more, never exclude more.

Adds benchmarks for the 'any' matcher, which had none.


Claude-Session: https://claude.ai/code/session_013LkknftdZWbXmTck1uMywn